### PR TITLE
Fixed Issue No. 7

### DIFF
--- a/exjson.py
+++ b/exjson.py
@@ -84,14 +84,14 @@ def _include_files(include_files_path, string, encoding=None, error_on_file_not_
                         included_source_surrounding_src = string.split(include_call_string)
                         included_source_surrounding_src_count = len(included_source_surrounding_src) - 1
                         for i in range(0, included_source_surrounding_src_count):
-                            included_call_pre_last_char = _get_last_char(included_source_surrounding_src[i])
+                            included_call_pre_last_char = _get_last_char(_remove_comments(included_source_surrounding_src[i]))
                             # Add comma at the beginning of the included code if required
                             if included_call_pre_last_char not in _JSON_OPENING_CHARS and included_source_first_char != ',':
                                 included_source = "," + included_source
                             # Add Trailing comma if code following the included statement does not have one.
                             if i < included_source_surrounding_src_count:
                                 if included_source_last_char != ',' and _get_first_char(
-                                        included_source_surrounding_src[i + 1]) not in _JSON_CLOSING_CHARS:
+                                        _remove_comments(included_source_surrounding_src[i + 1])) not in _JSON_CLOSING_CHARS:
                                     included_source = included_source + ','
                         string = string.replace(include_call_string, included_source)
                 else:

--- a/tests/exjson_test.py
+++ b/tests/exjson_test.py
@@ -175,14 +175,14 @@ class PyXJSONTests(TestCase):
         self.assertDictEqual(simple_json, {
             "Name": "Test",
             "Value": {
-            "Name": "Sample Values",
-            "Enabled": True,
-            "Values": [
-                "A",
-                "AB",
-                "ABC"
-            ],
-            "Count": 3
+                "Name": "Sample Values",
+                "Enabled": True,
+                "Values": [
+                    "A",
+                    "AB",
+                    "ABC"
+                ],
+                "Count": 3
             },
             "Enabled": True
         })
@@ -314,5 +314,58 @@ class PyXJSONTests(TestCase):
             "Other3": {
                 "Value_id": "4034A54700430B6A37E56B5C38070F6B1F333B7B",
                 "Value": "test message 2"
+            }
+        })
+
+    def test_loads_json_includes_followed_by_comment_before_EOF(self):
+        json_source = """{
+        // This tests that the include ignores comments
+        /* #INCLUDE <Test1:tests/samples/loads-include-test.json> */
+        "Name": "Test",
+        "Test": [
+            /* #INCLUDE <tests/samples/loads-include-test.json> */
+        ],
+        "Enabled": true,
+        // #INCLUDE <Value:tests/samples/loads-include-test.json>
+        /*
+        No more properties beyond here...
+        */
+        }
+        """
+        simple_json = exjson.loads(json_source, encoding='utf-8')
+        self.assertDictEqual(simple_json, {
+            "Name": "Test",
+            "Enabled": True,
+            "Test1": {
+                "Name": "Sample Values",
+                "Enabled": True,
+                "Values": [
+                    "A",
+                    "AB",
+                    "ABC"
+                ],
+                "Count": 3
+            },
+            "Test": [
+                {
+                    "Name": "Sample Values",
+                    "Enabled": True,
+                    "Values": [
+                        "A",
+                        "AB",
+                        "ABC"
+                    ],
+                    "Count": 3
+                }
+            ],
+            "Value": {
+                "Name": "Sample Values",
+                "Enabled": True,
+                "Values": [
+                    "A",
+                    "AB",
+                    "ABC"
+                ],
+                "Count": 3
             }
         })


### PR DESCRIPTION
Includes now ignores if comments before and after imported code. This prevents issues where the include logic will add commas after an imported json file right before a closing character generating an invalid json source code. Same applies to includes at the top of the file preceded by a comment.