### PR TITLE
Refactored call-graph generation logic and added unit test for prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,5 +107,6 @@ venv.bak/
 
 .idea
 
+tests/calls/*.png
 tests/*.png
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,25 @@
+import errno
+from os import path
+import os
+
+# Controls If Call Graphs will be generated and where they will be saved
+from tests import tools
+
+GENERATE_CALL_GRAPHS = True
+CALL_GRAPHS_PATH = path.abspath(path.join(".", "calls"))
+
+# Create Call diagrams folder
+if GENERATE_CALL_GRAPHS:
+    try:
+        os.makedirs(CALL_GRAPHS_PATH)
+    except OSError as ex:
+        if ex.errno == errno.EEXIST and os.path.isdir(CALL_GRAPHS_PATH):
+            pass
+        else:
+            raise
+
+def generate_call_graph(fn, *args, **kwargs):
+    if GENERATE_CALL_GRAPHS:
+        return tools.generate_call_graph(CALL_GRAPHS_PATH, fn, *args, **kwargs)
+    else:
+        return fn(*args, **kwargs)

--- a/tests/samples/include-without-property.json
+++ b/tests/samples/include-without-property.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Test 1",
+  /* #INCLUDE <clean-simple.json> */
+  "Value": "Test 2"
+}

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -4,7 +4,6 @@ from os import path
 from pycallgraph import PyCallGraph, Config, GlobbingFilter
 from pycallgraph.output import GraphvizOutput
 
-
 call_graph_config = Config()
 call_graph_config.trace_filter = GlobbingFilter(exclude=[
     'pycallgraph.*',
@@ -13,7 +12,7 @@ call_graph_config.trace_filter = GlobbingFilter(exclude=[
 
 def generate_call_graph(graph_path, func, *args, **kwargs):
     """Generates Call Graph for the called function"""
-    caller_func = inspect.stack()[1][3]
-    graphviz = GraphvizOutput(output_file=path.join(graph_path, "{0}.png".format(caller_func)))
-    with PyCallGraph(output=graphviz, config=call_graph_config):
+    caller_func = "test_" + func.__name__
+    with PyCallGraph(output=GraphvizOutput(output_file=path.join(graph_path, "{0}.png".format(caller_func)),
+                                           output_format="png"), config=call_graph_config):
         return func(*args, **kwargs)


### PR DESCRIPTION
Added unit test for missing property on include #INCLUDE <test.json> where it should be #INCLUDE <property:test.json> because no property is preceding the include directive.