### PR TITLE
Support for platform specific token + fixed incorrect week tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,39 +432,42 @@ EXJSON supports dynamic values by using an extensible scripting engine based on 
 |-------------|---------------------------|------------------------------------------------------------------|-------------|
 | dddd        |   %A                      | Weekday as locale’s full name.                                   | Monday      |
 | ddd         |   %a                      | Weekday as locale’s abbreviated name.                            | Mon         |
-| ***N/A**    |   %w                      | Weekday as a decimal number, where 0 is Sunday and 6 is Saturday.|  1          |
+| ww          |   %w                      | Weekday as a zero padded number, where 0 is Sunday and 6 is Saturday.|  01         |
+| w           |   %-w                      | Weekday as a decimal number, where 0 is Sunday and 6 is Saturday.|  1          |
 | dd          |   %d                      | Day of the month as a zero-padded decimal number.                | 30          |
-| d           |   %-d                     | Day of the month as a decimal number. |Platform specific)        | 30          |
+| d           |   %-d                     | Day of the month as a decimal number.         | 30          |
 | MMMM        |   %B                      | Month as locale’s full name.                                     | September   |
 | MMM         |   %b                      | Month as locale’s abbreviated name.                              | Sep         |
 | MM          |   %m                      | Month as a zero-padded decimal number.                           | 09          |
-| M           |   %-m                     | Month as a decimal number. |Platform specific)                   |  9          |
+| M           |   %-m                     | Month as a decimal number.                    |  9          |
 | yyyy        |   %Y                      | Year with century as a decimal number.                           | 2013        |
 | y           |   %y                      | Year without century as a zero-padded decimal number.            | 13          |
-| HH          |   %H                      | Hour |24-hour clock) as a zero-padded decimal number.            | 19          |
-| H           |   %-H                     | our |24-hour clock) as a decimal number. |Platform specific)     | 19          |
-| hh          |   %I                      | Hour |12-hour clock) as a zero-padded decimal number.            | 07          |
-| h           |   %-I                     | Hour |12-hour clock) as a decimal number. |Platform specific)    |  7          |
+| HH          |   %H                      | Hour (24-hour clock) as a zero-padded decimal number.            | 19          |
+| H           |   %-H                     | Hour (24-hour clock) as a decimal number.     | 19          |
+| hh          |   %I                      | Hour (12-hour clock) as a zero-padded decimal number.            | 07          |
+| h           |   %-I                     | Hour (12-hour clock) as a decimal number.     |  7          |
 | tt          |   %p                      | Locale’s equivalent of either AM or PM.                          | AM          |
 | mm          |   %M                      | Minute as a zero-padded decimal number.                          | 06          |
-| m           |   %-M                     | Minute as a decimal number. |Platform specific)                  |  6          |
+| m           |   %-M                     | Minute as a decimal number.                                      |  6          |
 | ss          |   %S                      | Second as a zero-padded decimal number.                          | 05          |
-| s           |   %-S                     | Second as a decimal number. |Platform specific)                  |  5          |  
+| s           |   %-S                     | Second as a decimal number.                   |  5          |  
 | f           |   %f                      | Microsecond as a decimal number, zero-padded on the left.        | 000000      |
-| zzz         |   %Z                      | Time zone name |empty string if the object is -00:00).           | -04:00      |
+| zzz         |   %Z                      | Time zone name (empty string if the object is -00:00).           | -04:00      |
 | z           |   %z                      | UTC offset in the form +HHMM or -HHMM.                           | -04:00      |
-| ***N/A**    |   %j                      | Day of the year as a zero-padded decimal number.                 | 273         |
-| ***N/A**    |   %-j                     | Day of the year as a decimal number. |Platform specific)         | 273         |
-| ***N/A**    |   %U                      | Week number of the year |Sunday as the first day of the week) as a zero padded decimal number. All days in a new year preceding the first Sunday are considered to be in week 0.        | 39 |
-| ***N/A**    |   %W                      | Week number of the year |Monday as the first day of the week) as a decimal number. All days in a new year preceding the first Monday are considered to be in week 0.                    | 39 |
-| q           |   **N/A**                 | Calendar Quarter as zero padded number.                           | 04          |
-| qq          |   **N/A**                 | Calendar Quarter as number.                                      |  4          |
+| j           |   %j                      | Day of the year as a zero-padded decimal number.                 | 273         |
+| jj          |   %-j                     | Day of the year as a decimal number.          | 273         |
+| UU          |   %U                      | Week number of the year (Sunday as the first day of the week) as a zero padded decimal number. All days in a new year preceding the first Sunday are considered to be in week 0.        | 09 |
+| U           |   %-U                     | Week number of the year (Sunday as the first day of the week) as a decimal number. All days in a new year preceding the first Sunday are considered to be in week 0.        |  9 |
+| WW          |   %W                      | Week number of the year (Monday as the first day of the week) as a zero padded decimal number. All days in a new year preceding the first Monday are considered to be in week 0.                    | 08 |
+| W           |   %W                      | Week number of the year (Monday as the first day of the week) as a decimal number. All days in a new year preceding the first Monday are considered to be in week 0.                    |  8 |
+| q           |   **custom**              | Calendar Quarter as zero padded number.                           | 04          |
+| qq          |   **custom**              | Calendar Quarter as number.                                      |  4          |
 | F           |   %c                      | Locale’s appropriate date and time representation.        | Mon Sep 30 07:06:05 2013 |
 | D           |   %x                      | Locale’s appropriate date representation.        | 09/30/13 |
 | T           |   %X                      | Locale’s appropriate time representation.        | 07:06:05 |
 | Z           |   %Y-%m-%dT%H:%m:%s.%f%z  | Zulu UTC ISO-8601                                | 2018-05-25T15:05:25.120Z |
-
-  `*N/A`: Is not available yet. May be included in future releases.  `N/A`: Is not supported by platform specified in column name.
+  
+  __No need to worry about running it on windows or linux. The universal format converter takes care of the platform specific tokens `-`/`#`.__
     
   
   * **NOW()**

--- a/scripting/extensions/datetime.py
+++ b/scripting/extensions/datetime.py
@@ -2,11 +2,7 @@ from datetime import datetime, timedelta
 
 from dateutil.tz import tzlocal
 
-def get_week(date: datetime.date):
-    return date.isocalendar()[1]
-
-def get_week_padded(date: datetime.date):
-    return str(get_week(date)).zfill(2)
+from scripting.extensions.tools import is_windows
 
 def get_quarter(date:datetime.date):
     return ((date.month-1)//3)+1
@@ -14,34 +10,40 @@ def get_quarter(date:datetime.date):
 def get_quarter_padded(date:datetime.date):
     return str(get_quarter(date)).zfill(2)
 
+_NOT_PADDING_CHAR = '-'
+if is_windows():
+    _NOT_PADDING_CHAR = '#'
 
 _DATETIME_FORMAT_MAP = [
     ("dddd", "%A", None),  # Weekday as locale’s full name. Ex. "Monday"
     ("ddd", "%a", None),  # Weekday as locale’s abbreviated name. Ex. "Mon"
-    ("w", None, get_week), # Weekday as a decimal number, where 0 is Sunday and 6 is Saturday. Ex. "1"
-    ("ww", None, get_week_padded), # Weekday as zero padded number
+    ("w", "%w", None), # Weekday as a decimal number, where 0 is Sunday and 6 is Saturday. Ex. "1"
+    ("ww", f"%{_NOT_PADDING_CHAR}w", None), # Weekday as zero padded number
     ("dd", "%d", None),  # Day of the month as a zero-padded decimal number. Ex. "30"
-    ("d", "%-d", None),  # Day of the month as a decimal number. (Platform specific) Ex. "30"
     ("MMMM", "%B", None),  # Month as locale’s full name. Ex. "September"
     ("MMM", "%b", None),  # Month as locale’s abbreviated name. Ex. "Sep"
     ("MM", "%m", None),  # Month as a zero-padded decimal number. Ex. "09"
-    ("M", "%-m", None),  # Month as a decimal number. (Platform specific) Ex. "9"
+    ("M", f"%{_NOT_PADDING_CHAR}m", None),  # Month as a decimal number. (Platform specific) Ex. "9"
     ("yyyy", "%Y", None),  # Year with century as a decimal number. Ex. "2013"
     ("y", "%y", None),  # Year without century as a zero-padded decimal number. Ex. "13"
     ("HH", "%H", None),  # Hour (24-hour clock) as a zero-padded decimal number. Ex. "07"
-    ("H", "%-H", None),  # Hour (24-hour clock) as a decimal number. (Platform specific) Ex. "7"
+    ("H", f"%{_NOT_PADDING_CHAR}H", None),  # Hour (24-hour clock) as a decimal number. (Platform specific) Ex. "7"
     ("hh", "%I", None),  # Hour (12-hour clock) as a zero-padded decimal number. Ex. "07"
-    ("h", "%-I", None),  # Hour (12-hour clock) as a decimal number. (Platform specific) Ex. "7"
+    ("h", f"%{_NOT_PADDING_CHAR}I", None),  # Hour (12-hour clock) as a decimal number. (Platform specific) Ex. "7"
     ("tt", "%p", None),  # Locale’s equivalent of either AM or PM. Ex. "AM"
     ("mm", "%M", None),  # Minute as a zero-padded decimal number. Ex. "06"
-    ("m", "%-M", None),  # Minute as a decimal number. (Platform specific) Ex. "6"
+    ("m", f"%{_NOT_PADDING_CHAR}M", None),  # Minute as a decimal number. (Platform specific) Ex. "6"
     ("ss", "%S", None),  # Second as a zero-padded decimal number. Ex. "05"
-    ("s", "%-S", None),  # Second as a decimal number. (Platform specific) Ex. "5"
+    ("s", f"%{_NOT_PADDING_CHAR}S", None),  # Second as a decimal number. (Platform specific) Ex. "5"
     ("f", "%f", None),  # Microsecond as a decimal number, zero-padded on the left. Ex. "000000"
     ("zzz", "%Z", None),  # Time zone name (empty string if the object is naive). Ex. ""
     ("z", "%z", None),  # UTC offset in the form +HHMM or -HHMM (empty string if the the object is naive). Ex. ""
     ("j", "%j", None),  # Day of the year as a zero-padded decimal number. Ex. "273"
-    ("jj", "%-j", None),  # Day of the year as a decimal number. (Platform specific) Ex. "273",
+    ("jj", f"%{_NOT_PADDING_CHAR}j", None),  # Day of the year as a decimal number. (Platform specific) Ex. "273",
+    ("WW", "%W", None), # Week number of the year (Sunday as the first day of the week) as a zero padded decimal number. All days in a new year preceding the first Sunday are considered to be in week 0
+    ("W", f"%{_NOT_PADDING_CHAR}W", None), # Week number of the year (Sunday as the first day of the week) as a decimal number. All days in a new year preceding the first Sunday are considered to be in week 0
+    ("UU", "%U", None), #Week number of the year (Monday as the first day of the week) as a zero padded decimal number. All days in a new year preceding the first Monday are considered to be in week 0.
+    ("U", f"%{_NOT_PADDING_CHAR}U", None), #Week number of the year (Monday as the first day of the week) as a decimal number. All days in a new year preceding the first Monday are considered to be in week 0.
     ("qq", None, get_quarter_padded), # Calendar Year quarter as padded number
     ("q", None, get_quarter), # Calendar Year quarter as integer
     ("F", "%c", None),  # Locale’s appropriate date and time representation. Ex. "Mon Sep 30 07:06:05 2013"

--- a/scripting/extensions/tools.py
+++ b/scripting/extensions/tools.py
@@ -1,6 +1,14 @@
+import os
+
+
 def get_null_value(value):
     """Gets None from null token"""
     if value.lower().strip(' ') == "null":
         return None
     else:
         return value
+
+def is_windows():
+    """Determines if the current operating system is a windows system"""
+    return os.name == "nt"
+

--- a/tests/exjson_test.py
+++ b/tests/exjson_test.py
@@ -704,7 +704,7 @@ class PyXJSONTests(TestCase):
     def test_loads_json_evaluate_python_formatted_now_week_and_quarter(self):
         result = tests.generate_call_graph(
             self._scenarios.loads_json_evaluate_raw_date_value, """{
-                    "date": "$.now('yyyy-MM-dd w q')"
+                    "date": "$.now('yyyy-MM-dd W q')"
                     }""", "formatted_now_week_and_quarter")
         v = f"{datetime.now().strftime('%Y-%m-%d')} {datetime.now().isocalendar()[1]} {datetime.now().month//4+1}"
         print(f"{v} {result[0]['date']}")


### PR DESCRIPTION
Added logic to support detection and calculation of platform specific tokens for not padded values.
Added correct week number format.
Updated documentation.